### PR TITLE
disable auto converting url text to links.

### DIFF
--- a/app/assets/javascripts/comfy/admin/cms/base.js.coffee
+++ b/app/assets/javascripts/comfy/admin/cms/base.js.coffee
@@ -80,6 +80,7 @@ window.CMS.wysiwyg = ->
     params = csrf_param + "=" + encodeURIComponent(csrf_token)
 
   $('textarea.rich-text-editor, textarea[data-cms-rich-text]').redactor
+    convertUrlLinks: false
     minHeight:        160
     autoresize:       true
     imageUpload:      "#{CMS.file_upload_path}?source=redactor&type=image&#{params}"


### PR DESCRIPTION
Set value of convertUrlLinks option to false so the WYSIWYG editor doesn't automatically convert url text to links.