### PR TITLE
CANDI-491: Add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+## Deprecation notice (Jora)
+
+The changes in this repo was moved to `jobengine` in this PR: https://github.com/jobseekerltd/jobengine/pull/3804
+
+This repository is now archived and no longer in use.
+
+----
+
+<br><br><br><br><br><br><br>
+
 # ComfortableMexicanSofa
 
 ComfortableMexicanSofa is a powerful Ruby on Rails 5.2+ CMS (Content Management System) Engine


### PR DESCRIPTION
The changes in this repo was moved to `jobengine` in this PR: https://github.com/jobseekerltd/jobengine/pull/3804

This PR adds a notice to describe that this repo should now be archived.

## References

- https://jobseeker.atlassian.net/browse/CANDI-491
- https://github.com/jobseekerltd/jobengine/pull/3804